### PR TITLE
Added search engine to osint section

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ A collection of awesome penetration testing resources
 * [ZoomEye](https://www.zoomeye.org/) - A cyberspace search engine for Internet-connected devices and websites using Xmap and Wmap
 * [recon-ng](https://bitbucket.org/LaNMaSteR53/recon-ng) - A full-featured Web Reconnaissance framework written in Python
 * [github-dorks](https://github.com/techgaun/github-dorks) - CLI tool to scan github repos/organizations for potential sensitive information leak
-
+* [MrLooquer] (https://mrlooquer.com/) - MrLooquer is a pioneering IPv6 search engine.
 #### Anonymity Tools
 * [Tor](https://www.torproject.org/) - The free software for enabling onion routing online anonymity
 * [I2P](https://geti2p.net/en/) - The Invisible Internet Project


### PR DESCRIPTION
Added search engine to osint section. Mrlooquer is a search engine focused on IPv6.
